### PR TITLE
Add option to consider event warps in logic

### DIFF
--- a/worlds/rabi_ribi/existing_randomizer/dataparser.py
+++ b/worlds/rabi_ribi/existing_randomizer/dataparser.py
@@ -1,6 +1,7 @@
 import ast, re, os
 from typing import Dict, List
 from worlds.rabi_ribi.existing_randomizer.utility import *
+from worlds.rabi_ribi.options import RabiRibiOptions
 
 """
 Knowledge levels:
@@ -615,6 +616,15 @@ def read_config(default_setting_flags, item_locations_set, shufflable_gift_items
     knowledge = config_dict['knowledge']
     difficulty = config_dict['trick_difficulty']
 
+    # Replace config file with player options
+    if hasattr(settings, 'ap_options'):
+        ap_options: RabiRibiOptions = settings.ap_options
+        read_ap_config_settings(config_settings, ap_options)
+        knowledge_options = ['BASIC', 'INTERMEDIATE', 'ADVANCED']
+        knowledge = knowledge_options[ap_options.knowledge.value]
+        difficulty_options = ['NORMAL', 'HARD', 'V_HARD', 'STUPID']
+        difficulty = difficulty_options[ap_options.trick_difficulty.value]
+
     if settings.shuffle_gift_items:
         included_additional_items = [item_name for item_name in included_additional_items if not item_name in shufflable_gift_items_set]
     else:
@@ -629,8 +639,6 @@ def read_config(default_setting_flags, item_locations_set, shufflable_gift_items
         if not type(value) is bool:
             fail('Flag %s does not map to a boolean variable in config.txt' % key)
         setting_flags[key] = value
-
-
     # Knowledge
     if knowledge == 'BASIC':
         setting_flags[KNOWLEDGE_INTERMEDIATE] = False
@@ -689,6 +697,20 @@ def read_config(default_setting_flags, item_locations_set, shufflable_gift_items
     )
 
     return setting_flags, to_shuffle, must_be_reachable, included_additional_items, config_data
+
+def read_ap_config_settings(config_settings, ap_options):
+    """Updates the default configuration settings with the player options from Archipelago."""
+    config_settings['DARKNESS_WITHOUT_LIGHT_ORB'] = bool(ap_options.darkness_without_light_orb.value)
+    config_settings['UNDERWATER_WITHOUT_WATER_ORB'] = bool(ap_options.underwater_without_water_orb.value)
+    config_settings['ZIP_REQUIRED'] = bool(ap_options.zips_required.value)
+    config_settings['SEMISOLID_CLIPS_REQUIRED'] = bool(ap_options.semi_solid_clips_required.value)
+    config_settings['BLOCK_CLIPS_REQUIRED'] = bool(ap_options.block_clips_required.value)
+    config_settings['PLURKWOOD_REACHABLE'] = bool(ap_options.plurkwood_reachable.value)
+    config_settings['EVENT_WARPS_REQUIRED'] = bool(ap_options.event_warps_in_logic.value)
+    config_settings['POST_GAME_ALLOWED'] = False
+    config_settings['POST_IRISU_ALLOWED'] = False
+    config_settings['HALLOWEEN_REACHABLE'] = False
+    config_settings['WARP_DESTINATION_REACHABLE'] = False
 
 def parse_item_from_string(line):
     pos, areaid, itemid, name = (s.strip() for s in line.split(':', 3))

--- a/worlds/rabi_ribi/logic_helpers.py
+++ b/worlds/rabi_ribi/logic_helpers.py
@@ -436,7 +436,7 @@ def convert_existing_rando_rule_to_ap_rule(existing_rule: object, player: int, r
             "Zip Required": lambda _: options.zips_required.value,
             "Plurkwood Reachable": lambda _: options.plurkwood_reachable.value,
             "Boss Keke Bunny" : lambda state: can_reach_keke_bunny(state, player),
-            "Event Warp" : lambda _: options.event_warps_in_logic.value
+            "Event Warps Required" : lambda _: options.event_warps_in_logic.value
         }
         if literal in literal_eval_map:
             return literal_eval_map[literal]

--- a/worlds/rabi_ribi/logic_helpers.py
+++ b/worlds/rabi_ribi/logic_helpers.py
@@ -435,7 +435,8 @@ def convert_existing_rando_rule_to_ap_rule(existing_rule: object, player: int, r
             "Semisolid Clips Required": lambda _: options.semi_solid_clips_required.value,
             "Zip Required": lambda _: options.zips_required.value,
             "Plurkwood Reachable": lambda _: options.plurkwood_reachable.value,
-            "Boss Keke Bunny" : lambda state: can_reach_keke_bunny(state, player)
+            "Boss Keke Bunny" : lambda state: can_reach_keke_bunny(state, player),
+            "Event Warp" : lambda _: options.event_warps_in_logic.value
         }
         if literal in literal_eval_map:
             return literal_eval_map[literal]

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -110,13 +110,21 @@ class PlurkwoodReachable(Toggle):
     """
     display_name = "Plurkwood Reachable"
 
+class EventWarpsInLogic(Toggle):
+    """
+    If this flag is true, events that warp the player to another location are considered in logic.
+    While some of these events can only be reached once normally, the randomizer adds doors that
+    allow these events to be accessed multiple times.
+    """
+    display_name = "Event Warps in Logic"
+
 class AttackMode(Choice):
     """
     Normal attack mode starts you with 0 attack ups.
     Super attack mode starts you with 20 attack ups.
     Hyper attack mode starts you with 30 attack ups.
 
-    This gives you a lot more damage, which is especially useful because you often don’t get
+    This gives you a lot more damage, which is especially useful because you often don't get
     the hammer early in randomizer games. (Ribbon does about 20 damage per shot in super attack mode)
     """
     display_name = "Attack Mode"
@@ -164,8 +172,6 @@ class ShuffleBackgrounds(Toggle):
 class RabiRibiOptions(PerGameCommonOptions):
     """Rabi Ribi Options Definition"""
     open_mode: OpenMode
-    randomize_hammer: RandomizeHammer
-    randomize_gift_items: RandomizeGiftItems
     knowledge: Knowledge
     trick_difficulty: TrickDifficulty
     block_clips_required: BlockClipsRequired
@@ -173,10 +179,16 @@ class RabiRibiOptions(PerGameCommonOptions):
     zips_required: ZipsRequired
     darkness_without_light_orb: DarknessWithoutLightOrb
     underwater_without_water_orb: UnderwaterWithoutWaterOrb
+    carrot_shooter_in_logic: CarrotShooterInLogic
+    event_warps_in_logic: EventWarpsInLogic
+
     attack_mode: AttackMode
     encourage_eggs_in_late_spheres: EncourageEggsInLateSpheres
-    carrot_shooter_in_logic: CarrotShooterInLogic
+
+    randomize_hammer: RandomizeHammer
+    randomize_gift_items: RandomizeGiftItems
     plurkwood_reachable: PlurkwoodReachable
+
     enable_constraint_changes: EnableConstraintChanges
     number_of_constraint_changes: NumberOfConstraintChanges
     shuffle_map_transitions: ShuffleMapTransitions

--- a/worlds/rabi_ribi/regions.py
+++ b/worlds/rabi_ribi/regions.py
@@ -115,6 +115,7 @@ class RegionDef:
 
     def _convert_options_to_existing_randomizer_args(self, options: RabiRibiOptions):
         args = parse_args()
+        args.ap_options = options
         args.open_mode = options.open_mode.value
         args.shuffle_gift_items = options.randomize_gift_items.value
         args.shuffle_map_transitions = options.shuffle_map_transitions.value


### PR DESCRIPTION
Rearranged player options to hopefully be more organized.

Fixed some AP settings not being set in the existing randomizer's settings.
- Some settings come from a `config.txt` file and weren't being overridden. This shouldn't affect generation for the most part, but there's the possibility of a constraint that only is bypassable with harder tricks.

Added the option "Event Warps in Logic" that allows event transitions to be considered in logic. Specifically, there are four events that force a map transition:
- The UPRPR fight in Starting Forest after beating Ribbon: Warps to Beach from Forest
- Recruiting Cicini: Warps to Ravine outside Town
- Chapter 2 event to find lab: Warps to Riverbank Level 1 outside Forest
- Beating Plurkwood: Warps to Town

While the first 3 are normally one time events, the randomizer adds doors that allow you to re-trigger these events.

Example topology:
```
Egg Park Green Kotri
        Menu -> Menu -> Forest Start
   =>   Forest Start -> Forest Start -> Cave Entrance
   =>   Cave Entrance -> Cave Entrance -> Spectral Upper
   =>   Spectral Upper -> Spectral Upper -> Spectral Warp
   =>   Spectral Warp -> Spectral Warp -> Spectral Mid
   =>   Spectral Mid -> Spectral Mid -> Spectral West
   =>   Spectral West -> Spectral West -> Park Town Entrance (!!!)
   =>   Park Town Entrance -> Park Town Entrance -> Park Kotri
   =>   Park Kotri -> Park Kotri -> Item Egg Park Green Kotri
   =>   Item Egg Park Green Kotri
```