### PR TITLE
Add Start Location shuffle

### DIFF
--- a/worlds/rabi_ribi/__init__.py
+++ b/worlds/rabi_ribi/__init__.py
@@ -104,7 +104,7 @@ class RabiRibiWorld(World):
         """
         self.topology_present = bool(self.options.shuffle_map_transitions.value)
 
-        region_def = RegionDef(self.multiworld, self.player, self.options)
+        region_def = RegionDef(self)
 
         # Generate a world seed using the existing randomizer
         if self.should_regenerate_seed_for_universal_tracker():
@@ -148,6 +148,8 @@ class RabiRibiWorld(World):
             "plurkwood_reachable": bool(self.options.plurkwood_reachable.value),
             "picked_templates": self.picked_templates,
             "map_transition_shuffle_order": self.map_transition_shuffle_order,
+            "shuffle_start_location": bool(self.options.shuffle_start_location.value),
+            "start_location": self.start_location,
             "shuffle_music": bool(self.options.shuffle_music.value),
             "shuffle_backgrounds": bool(self.options.shuffle_backgrounds.value)
         }
@@ -171,6 +173,8 @@ class RabiRibiWorld(World):
                 self.multiworld.get_location(LocationName.p_hairpin, self.player).place_locked_item(self.create_item(ItemName.p_hairpin))
 
     def write_spoiler(self, spoiler_handle: TextIO) -> None:
+        spoiler_handle.write(f'\nStart Location: {self.start_location}\n')
+
         spoiler_handle.write(f'\nApplied Map Constraints:\n')
         for template in self.picked_templates:
             spoiler_handle.write(f'\n{convert_existing_rando_name_to_ap_name(template)}')

--- a/worlds/rabi_ribi/entrance_shuffle.py
+++ b/worlds/rabi_ribi/entrance_shuffle.py
@@ -34,7 +34,7 @@ class MapAllocation(Allocation):
         # Choose Starting Location
         self.choose_starting_location(data, settings)
 
-    def construct_set_seed(self, data, settings, picked_templates:List[str], map_transition_shuffle_order: List[int]):
+    def construct_set_seed(self, data, settings, picked_templates:List[str], map_transition_shuffle_order: List[int], start_location: str):
         self.map_modifications = list(data.default_map_modifications)
 
         # Apply the selected templates for the graph
@@ -52,6 +52,7 @@ class MapAllocation(Allocation):
 
         self.construct_graph(data, settings)
 
+        self.start_location = next((location for location in data.start_locations if location.location == start_location), data.start_locations[0])
 
 class MapGenerator(object):
     """The MapAnalyzer class is an reimplementation of the Generator class with simplified validation,

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -168,6 +168,12 @@ class ShuffleBackgrounds(Toggle):
     """
     display_name = "Shuffle Backgrounds"
 
+class ShuffleStartLocation(Toggle):
+    """
+    If this flag is true, the randomizer will start the player at one of several locations
+    around Rabi Rabi Island.
+    """
+    display_name = "Shuffle Start Location"
 
 @dataclass
 class RabiRibiOptions(PerGameCommonOptions):
@@ -193,5 +199,6 @@ class RabiRibiOptions(PerGameCommonOptions):
     enable_constraint_changes: EnableConstraintChanges
     number_of_constraint_changes: NumberOfConstraintChanges
     shuffle_map_transitions: ShuffleMapTransitions
+    shuffle_start_location: ShuffleStartLocation
     shuffle_music: ShuffleMusic
     shuffle_backgrounds: ShuffleBackgrounds


### PR DESCRIPTION
- Added an option to enable the Shuffle Start Location option in the standalone randomizer.
- Updated the Spoiler Log to include the start location.

Note: Shuffling the start location increases the chance of an unbeatable seed, due to AP assuming access to the start location at all times. I'll be working on addressing this in the next PR.
