### PR TITLE
Make locations collectable for player's own "Nothing"

### DIFF
--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -503,7 +503,7 @@ async def check_for_locations(ctx: RabiRibiContext):
 
         try:
             network_item = await asyncio.wait_for(ctx.obtained_items_queue.get(), timeout=15)
-            if network_item.player != ctx.slot:
+            if network_item.player != ctx.slot or (network_item.player == ctx.slot and ctx.item_names.lookup_in_game(network_item.item) == "Nothing"):
                 await remove_exclamation_point(ctx, coordinates)
         except TimeoutError:
             logger.warning("Never received response to scout request for ap_location_id %d", ap_location_id)

--- a/worlds/rabi_ribi/existing_randomizer/randomizer.py
+++ b/worlds/rabi_ribi/existing_randomizer/randomizer.py
@@ -590,7 +590,6 @@ def insert_items_into_map(mod, data, settings, allocation):
         item_at_location = allocation.item_at_item_location[item.name]
         # AP Change: Place player's own "Nothing" as an AP item
         # to behave better with AP's hint point system.
-        # TODO: Stop the item from reappearing after collection.
         if item_at_location != None:
             if item_at_location in cur_stat_boost_ids:
                 item.itemid = cur_stat_boost_ids[item_at_location]

--- a/worlds/rabi_ribi/existing_randomizer/randomizer.py
+++ b/worlds/rabi_ribi/existing_randomizer/randomizer.py
@@ -588,11 +588,13 @@ def insert_items_into_map(mod, data, settings, allocation):
         if item.name not in allocation.item_at_item_location:
             continue
         item_at_location = allocation.item_at_item_location[item.name]
-        if item_at_location != None and item_at_location != "NOTHING":
+        # AP Change: Place player's own "Nothing" as an AP item
+        # to behave better with AP's hint point system.
+        if item_at_location != None:
             if item_at_location in cur_stat_boost_ids:
                 item.itemid = cur_stat_boost_ids[item_at_location]
                 cur_stat_boost_ids[item_at_location] += 1
-            elif item_at_location == "ANOTHER_PLAYERS_ITEM":
+            elif item_at_location == "ANOTHER_PLAYERS_ITEM" or item_at_location == "NOTHING":
                 item.itemid = 43
             elif item_at_location == "EASTER_EGG":
                 item.itemid = -250

--- a/worlds/rabi_ribi/existing_randomizer/randomizer.py
+++ b/worlds/rabi_ribi/existing_randomizer/randomizer.py
@@ -590,6 +590,7 @@ def insert_items_into_map(mod, data, settings, allocation):
         item_at_location = allocation.item_at_item_location[item.name]
         # AP Change: Place player's own "Nothing" as an AP item
         # to behave better with AP's hint point system.
+        # TODO: Stop the item from reappearing after collection.
         if item_at_location != None:
             if item_at_location in cur_stat_boost_ids:
                 item.itemid = cur_stat_boost_ids[item_at_location]


### PR DESCRIPTION
- The map generator now places the player's own "Nothing" as a collectable "!" item, the same as an AP item.
- Collecting your own "Nothing" item behaves the same as picking up another player's AP item.

Made these changes so that players won't be missing out on hint points due to having nothing to collect at locations that have "Nothing" placed there. (Should also behave better with autotracking now that there is a poptracker pack being developed.)

Tested this in a couple of generations and it seems to work as expected.