### PR TITLE
Add option to warp anywhere

### DIFF
--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -330,9 +330,7 @@ class RabiRibiContext(CommonContext):
     def in_state_where_should_open_warp_menu(self):
         cur_time = time.time()
         return (
-            (cur_time - self.time_since_last_paused >= 2) and
-            (cur_time - self.time_since_last_warp_menu >= 5.5) and
-            (cur_time - self.time_since_last_costume_menu >= 2) and
+            (cur_time - self.time_since_last_paused >= .5) and
             not self.rr_interface.is_player_frozen() and
             not self.is_item_queued() and
             self.rr_interface.get_item_state(STRANGE_BOX_ITEM_ID) == -1

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -197,11 +197,12 @@ class RabiRibiContext(CommonContext):
             await asyncio.sleep(1)
             logger.info("Received initial data from server!")
             logger.info("****************************************************")
-            logger.info("Please press f5 on the main menu and start scenario:")
+            logger.info("Please press F5 on the main menu and start scenario:")
             logger.info("       %s - %s",
                 self.seed_name,
                 self.auth)
             logger.info("****************************************************")
+            logger.info("Softlocked? Disable the Strange Box in your inventory and unpause to open the warp menu!")
 
     def patch_if_recieved_all_data(self):
         """

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -123,7 +123,7 @@ class RabiRibiMemoryIO():
         :returns: The data represented as a float.
         """
         data = self._read_word(offset)
-        if (struct.unpack("<i", data)[0] == 0):
+        if (struct.unpack("i", data)[0] == 0):
             return False
         return True
 

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -21,7 +21,6 @@ OFFSET_PLAYER_Y = int(0x013AFDB4)
 OFFSET_GIVE_ITEM_FUNC = int(0x15A90)
 OFFSET_PLAYER_FROZEN = int(0x1031DDC)
 OFFSET_ITEM_MAP = int(0xDFFB3C)
-OFFSET_INVENTORY_EXCLAMATION_POINT = int(0x1673050)
 OFFSET_INVENTORY_START = int(0x1672FA4)
 OFFSET_MAX_HEALTH = int(0x16E6D24)
 OFFSET_EGG_COUNT = int(0x1675CCC)
@@ -30,6 +29,8 @@ OFFSET_SCENERIO_INDICATOR = int(0xE30880)
 OFFSET_IN_ITEM_GET_ANIMATION = int(0x1682ACA)
 OFFSET_IN_WARP_MENU = int(0x16E5BB8)
 OFFSET_IN_COSTUME_MENU = int(0x16E6B20)
+OFFSET_CURRENT_WARP_ID = int(0x016E6D08)
+EXCLAMATION_POINT_ITEM_ID = 43
 TILE_LENGTH = 64
 
 class RabiRibiMemoryIO():
@@ -122,7 +123,7 @@ class RabiRibiMemoryIO():
         :returns: The data represented as a float.
         """
         data = self._read_word(offset)
-        if (struct.unpack("i", data)[0] == 0):
+        if (struct.unpack("<i", data)[0] == 0):
             return False
         return True
 
@@ -243,20 +244,49 @@ class RabiRibiMemoryIO():
 
     def remove_exclamation_point_from_inventory(self):
         """
-        This removes the exclamation point item (the item that represents other worlds' items
-        to false, and takes it away from the player after its recieved)
+        Removes the exclamation point item (used to represent items from other worlds)
+        from the player's inventory.
         """
-        self.rr_mem.write_bytes(
-            self.rr_mem.base_address + OFFSET_INVENTORY_EXCLAMATION_POINT,
-            b'\x00\x00\x00\x00',
-            4
-        )
+        self.set_item_state(EXCLAMATION_POINT_ITEM_ID, 0)
 
     def does_player_have_item_id(self, item_id) -> bool:
         """
         Returns true if player currently has item_id in their inventory.
         """
         return self._read_4_byte_bool(OFFSET_INVENTORY_START + (4 * int(item_id)))
+
+    def get_item_state(self, item_id) -> int:
+        """
+        Returns the state of an item in the player's inventory.
+
+        If 0, the player does not have the item.
+        If 1, the player does have the item.
+        If 2 or 3, the player has the item, along with an upgrade.
+        If -1, -2, or -3, the player has the item, but has disabled it.
+        """
+        return self._read_int(OFFSET_INVENTORY_START + (4 * int(item_id)))
+
+    def set_item_state(self, item_id, state):
+        """
+        Returns the state of an item in the player's inventory.
+
+        If 0, the player does not have the item.
+        If 1, the player does have the item.
+        If 2 or 3, the player has the item, along with an upgrade.
+        If -1, -2, or -3, the player has the item, but has disabled it.
+        """
+        self.rr_mem.write_int(self.rr_mem.base_address + OFFSET_INVENTORY_START + (4 * int(item_id)), state)
+
+    def open_warp_menu(self):
+        """
+        Opens the warp menu.
+        """
+        self.rr_mem.write_int(self.rr_mem.base_address + OFFSET_IN_WARP_MENU, 1)
+
+        # When using the warp menu, the player cannot select to warp to their current location.
+        # Since we're opening the menu in a random location, we need to set the current location to not be 0
+        # to allow warping to Starting Forest. We use Forgotten Cave 2, as it's an unnecessary warp.
+        self.rr_mem.write_int(self.rr_mem.base_address + OFFSET_CURRENT_WARP_ID, 13)
 
     def get_number_of_eggs_collected(self) -> int:
         """

--- a/worlds/rabi_ribi/existing_randomizer/randomizer.py
+++ b/worlds/rabi_ribi/existing_randomizer/randomizer.py
@@ -369,6 +369,9 @@ def configure_shaft(mod, settings):
         # Add ribbon
         events_list.append((558, 5008, 5001))
 
+    # AP Change: Give player Strange Box, used to return to start.
+    events_list.append((558, 5030, 5001))
+
     # Add attack ups
     if settings.hyper_attack_mode:
         for i in range(0,30):


### PR DESCRIPTION
With starting location shuffle, it's easy for players to end up softlocked due to paths that are one-way only without additional items.

- Added a way for players to warp to any teleporter
  - This feature is activated by disabling the item Strange Box in the player's inventory
- Updated client to mention this new feature on connection