### PR TITLE
Rabi-Ribi: Add deathlink logic

### DIFF
--- a/worlds/rabi_ribi/__init__.py
+++ b/worlds/rabi_ribi/__init__.py
@@ -159,7 +159,8 @@ class RabiRibiWorld(World):
             "shuffle_start_location": bool(self.options.shuffle_start_location.value),
             "start_location": self.start_location,
             "shuffle_music": bool(self.options.shuffle_music.value),
-            "shuffle_backgrounds": bool(self.options.shuffle_backgrounds.value)
+            "shuffle_backgrounds": bool(self.options.shuffle_backgrounds.value),
+            "death_link": bool(self.options.death_link.value)
         }
 
     def set_rules(self) -> None:

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -32,6 +32,10 @@ OFFSET_IN_ITEM_GET_ANIMATION = int(0x1682ACA)
 OFFSET_IN_WARP_MENU = int(0x16E5BB8)
 OFFSET_IN_COSTUME_MENU = int(0x16E6B20)
 OFFSET_CURRENT_WARP_ID = int(0x016E6D08)
+ # returns a memory address where various state is stored
+OFFSET_CURRENT_HEALTH_A = int(0x1682364)
+# offset from the address returned by A
+OFFSET_CURRENT_HEALTH_B = int(0x4E0)
 EXCLAMATION_POINT_ITEM_ID = 43
 UNUSED_ITEM_ID_48 = 48
 TILE_LENGTH = 64
@@ -83,6 +87,7 @@ class RabiRibiMemoryIO():
         :int offset: the offset to read data from.
         :returns: The data represented as a byte string
         """
+        
         data = self.rr_mem.read_bytes(self.rr_mem.base_address + offset, 4)
         return data
     
@@ -333,7 +338,7 @@ class RabiRibiMemoryIO():
         """
         True if the player isnt loaded into a game.
         """
-        return not self._read_4_byte_bool(OFFSET_MAX_HEALTH)
+        return not self._read_4_byte_bool(OFFSET_MAX_HEALTH) and not self.is_player_paused()
 
     def is_in_warp_menu(self) -> bool:
         """
@@ -346,3 +351,15 @@ class RabiRibiMemoryIO():
         True if the player is currently selecting a costume
         """
         return self._read_4_byte_bool(OFFSET_IN_COSTUME_MENU)
+
+    def has_zero_health(self) -> bool:
+        """
+        True if the player's health is at 0
+        """
+        return not self._read_4_byte_bool(OFFSET_MAX_HEALTH)
+
+    def set_player_health_to_zero(self):
+        """
+        Sets the player health to 0
+        """
+        self.rr_mem.write_bytes(self._read_int(OFFSET_CURRENT_HEALTH_A) + OFFSET_CURRENT_HEALTH_B, b'\x00\x00\x00\x00', 4)

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -33,9 +33,9 @@ OFFSET_IN_WARP_MENU = int(0x16E5BB8)
 OFFSET_IN_COSTUME_MENU = int(0x16E6B20)
 OFFSET_CURRENT_WARP_ID = int(0x016E6D08)
  # returns a memory address where various state is stored
-OFFSET_CURRENT_HEALTH_A = int(0x1682364)
-# offset from the address returned by A
-OFFSET_CURRENT_HEALTH_B = int(0x4E0)
+OFFSET_PLAYER_STATE = int(0x1682364)
+# offset from the address from OFFSET_PLAYER_STATE
+OFFSET_PLAYER_STATE_HEALTH = int(0x4E0)
 EXCLAMATION_POINT_ITEM_ID = 43
 UNUSED_ITEM_ID_48 = 48
 TILE_LENGTH = 64
@@ -362,4 +362,5 @@ class RabiRibiMemoryIO():
         """
         Sets the player health to 0
         """
-        self.rr_mem.write_bytes(self._read_int(OFFSET_CURRENT_HEALTH_A) + OFFSET_CURRENT_HEALTH_B, b'\x00\x00\x00\x00', 4)
+        player_state_health_address = self._read_int(OFFSET_PLAYER_STATE) + OFFSET_PLAYER_STATE_HEALTH
+        self.rr_mem.write_int(player_state_health_address, 0)

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -1,7 +1,7 @@
 """This module represents option defintions for Rabi-Ribi"""
 from dataclasses import dataclass
 
-from Options import PerGameCommonOptions, Choice, Range, Toggle
+from Options import PerGameCommonOptions, Choice, Range, Toggle, DeathLink
 
 class OpenMode(Toggle):
     """Gain access to chapter 1 areas without needing to complete the prologue"""
@@ -202,3 +202,4 @@ class RabiRibiOptions(PerGameCommonOptions):
     shuffle_start_location: ShuffleStartLocation
     shuffle_music: ShuffleMusic
     shuffle_backgrounds: ShuffleBackgrounds
+    death_link: DeathLink


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Adding deathlink to Rabi-Ribi, works by reading/writing player health, Deaths from other games are stored in a buffer which is cleared when death occurs, though making the player sit through all the deaths could be an option.

## How was this tested?

Tested in multiple AP games, no major bugs found

## If this makes graphical changes, please attach screenshots.
