### PR TITLE
Allow Higher Amounts of Easter Eggs as a Win Condition

### DIFF
--- a/worlds/rabi_ribi/__init__.py
+++ b/worlds/rabi_ribi/__init__.py
@@ -2,12 +2,13 @@
 This module serves as an entrypoint into the Rabi-Ribi AP world.
 """
 import math
-import settings
 import logging
+import settings
 from collections import defaultdict
 from typing import Any, ClassVar, Dict, List, Optional, Set, TextIO, Union
 from BaseClasses import ItemClassification, Tutorial
 from Fill import swap_location_item
+from Options import Toggle
 from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import Component, Type, components, launch_subprocess
 from .existing_randomizer.dataparser import RandomizerData
@@ -105,6 +106,10 @@ class RabiRibiWorld(World):
         """Set world specific generation properties"""
         # Universal Tracker: Load options from slot data instead of YAML
         ut_helpers.apply_options_from_slot_data_if_available(self)
+
+        if not self.options.open_mode.value and self.options.shuffle_start_location.value:
+            logging.warning(f"Rabi-Ribi: Enabling open mode for Player {self.player} ({self.player_name}) due to shuffled start location.")
+            self.options.open_mode.value = Toggle.option_true
 
         self.existing_randomizer_args = self._convert_options_to_existing_randomizer_args()
         self.randomizer_data = RandomizerData(self.existing_randomizer_args)

--- a/worlds/rabi_ribi/__init__.py
+++ b/worlds/rabi_ribi/__init__.py
@@ -5,6 +5,7 @@ import math
 import logging
 import settings
 from collections import defaultdict
+from itertools import chain
 from typing import Any, ClassVar, Dict, List, Optional, Set, TextIO, Union
 from BaseClasses import ItemClassification, Tutorial
 from Fill import swap_location_item
@@ -160,10 +161,14 @@ class RabiRibiWorld(World):
         region_helper.configure_region_spoiler_log_data()
 
     def get_filler_item_name(self) -> str:
+        """Called when the item pool needs to be filled with additional items to match location count."""
         if self.filler_items is None:
-            self.filler_items = [item for sublist in [([key] * value) for key, value in filler_items.items()] for item in sublist]
+            # Create a list of lists for every potion, then flatten and shuffle
+            all_potions_grouped = [([key] * value) for key, value in filler_items.items()]
+            self.filler_items = list(chain(*all_potions_grouped))
             self.random.shuffle(self.filler_items)
         if len(self.filler_items) == 0:
+            # All potions placed
             return ItemName.nothing
         return self.filler_items.pop(0)
 

--- a/worlds/rabi_ribi/__init__.py
+++ b/worlds/rabi_ribi/__init__.py
@@ -152,7 +152,7 @@ class RabiRibiWorld(World):
         region_helper.configure_region_spoiler_log_data()
 
     def create_items(self) -> None:
-        base_item_list = get_base_item_list(self.randomizer_data)
+        base_item_list = get_base_item_list(self.options, self.randomizer_data)
 
         for item in map(self.create_item, base_item_list):
             if (not self.options.randomize_hammer.value) and (item.name == ItemName.piko_hammer):
@@ -170,6 +170,7 @@ class RabiRibiWorld(World):
 
     def fill_slot_data(self) -> dict:
         return {
+            "number_of_easter_eggs": self.options.number_of_easter_eggs.value,
             "openMode": bool(self.options.open_mode.value),
             "attackMode": self.options.attack_mode.value,
             "randomize_gift_items": bool(self.options.randomize_gift_items.value),
@@ -213,7 +214,7 @@ class RabiRibiWorld(World):
         Set remaining rules (for now this is just the win condition).
         """
         self.multiworld.completion_condition[self.player] = \
-            lambda state: state.has(ItemName.easter_egg, self.player, 5)
+            lambda state: state.has(ItemName.easter_egg, self.player, self.options.number_of_easter_eggs.value)
 
     def pre_fill(self) -> None:
         if not self.options.randomize_hammer.value:

--- a/worlds/rabi_ribi/__init__.py
+++ b/worlds/rabi_ribi/__init__.py
@@ -1,17 +1,18 @@
 """
 This module serves as an entrypoint into the Rabi-Ribi AP world.
 """
+import math
 import settings
 import logging
 from collections import defaultdict
-from typing import Any, ClassVar, Dict, List, Set, TextIO, Union
+from typing import Any, ClassVar, Dict, List, Optional, Set, TextIO, Union
 from BaseClasses import ItemClassification, Tutorial
 from Fill import swap_location_item
 from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import Component, Type, components, launch_subprocess
 from .existing_randomizer.dataparser import RandomizerData
 from .existing_randomizer.randomizer import parse_args
-from .items import RabiRibiItem, RabiRibiItemData, item_data_table, item_groups, shufflable_gift_items, shufflable_gift_items_plurkwood, item_table, get_base_item_list
+from .items import RabiRibiItem, RabiRibiItemData, item_data_table, item_groups, shufflable_gift_items, shufflable_gift_items_plurkwood, item_table, filler_items, get_base_item_list
 from .locations import all_locations, location_groups
 from .names import ItemName, LocationName
 from .options import RabiRibiOptions
@@ -85,11 +86,13 @@ class RabiRibiWorld(World):
     item_name_to_id = item_table
     location_name_to_id: Dict[str, int] = all_locations
 
+    total_locations: int
+    required_egg_count: int
     start_location: str
     picked_templates: List[str]
-    total_locations: int
     map_transition_shuffle_order: List[int]
     map_transition_shuffle_spoiler: List[str]
+    filler_items: Optional[List[str]] = None
     existing_randomizer_args: Any
     randomizer_data: RandomizerData
 
@@ -151,8 +154,21 @@ class RabiRibiWorld(World):
         region_helper.configure_slot_data()
         region_helper.configure_region_spoiler_log_data()
 
+    def get_filler_item_name(self) -> str:
+        if self.filler_items is None:
+            self.filler_items = [item for sublist in [([key] * value) for key, value in filler_items.items()] for item in sublist]
+            self.random.shuffle(self.filler_items)
+        if len(self.filler_items) == 0:
+            return ItemName.nothing
+        return self.filler_items.pop(0)
+
     def create_items(self) -> None:
         base_item_list = get_base_item_list(self.options, self.randomizer_data)
+        max_egg_locations_in_pool = self.total_locations - len(base_item_list)
+        total_egg_count = min(max_egg_locations_in_pool, self.options.max_number_of_easter_eggs.value)
+        self.required_egg_count = max(math.floor(total_egg_count * (self.options.percentage_of_easter_eggs.value / 100.0)), 1)
+
+        base_item_list.extend([ItemName.easter_egg] * total_egg_count)
 
         for item in map(self.create_item, base_item_list):
             if (not self.options.randomize_hammer.value) and (item.name == ItemName.piko_hammer):
@@ -166,11 +182,11 @@ class RabiRibiWorld(World):
             self.multiworld.itempool.append(item)
 
         junk = self.total_locations - len(base_item_list)
-        self.multiworld.itempool += [self.create_item(ItemName.nothing) for _ in range(junk)]
+        self.multiworld.itempool += [self.create_item(self.get_filler_item_name()) for _ in range(junk)]
 
     def fill_slot_data(self) -> dict:
         return {
-            "number_of_easter_eggs": self.options.number_of_easter_eggs.value,
+            "required_egg_count": self.required_egg_count,
             "openMode": bool(self.options.open_mode.value),
             "attackMode": self.options.attack_mode.value,
             "randomize_gift_items": bool(self.options.randomize_gift_items.value),
@@ -214,7 +230,7 @@ class RabiRibiWorld(World):
         Set remaining rules (for now this is just the win condition).
         """
         self.multiworld.completion_condition[self.player] = \
-            lambda state: state.has(ItemName.easter_egg, self.player, self.options.number_of_easter_eggs.value)
+            lambda state: state.has(ItemName.easter_egg, self.player, self.required_egg_count)
 
     def pre_fill(self) -> None:
         if not self.options.randomize_hammer.value:

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -72,7 +72,6 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         self.current_room: Tuple[int, int] = (-1, 1)
         self.state_giving_item = False
         self.collected_eggs: Set[Tuple[int,int,int]] = set()
-        self.last_received_item_index = -1
         self.seed_name = None
         self.slot_data = None
 
@@ -274,15 +273,14 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
 
         :NetworkItem item: The item to give to the player
         """
-        self.last_received_item_index = self.rr_interface.get_last_received_item_index()
-
         # Find the first item ID that the player has not recieved yet
-        remaining_items = self.items_received_rabi_ribi_ids[self.last_received_item_index:]
+        last_received_item_index = self.rr_interface.get_last_received_item_index()
+        remaining_items = self.items_received_rabi_ribi_ids[last_received_item_index:]
         skipped_items, cur_item_id = next(((idx, item_id) for idx, item_id in enumerate(remaining_items) if item_id != -1), (-1, -1))
 
         if cur_item_id > 0:
             self.rr_interface.give_item(cur_item_id)
-            self.rr_interface.set_last_received_item_index(self.last_received_item_index + skipped_items + 1)
+            self.rr_interface.set_last_received_item_index(last_received_item_index + skipped_items + 1)
             await asyncio.sleep(1)
             await self.wait_until_out_of_item_receive_animation()
 
@@ -319,7 +317,9 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         currently has it in their inventory
         """
         if self.items_received:
-            for item_id in self.items_received_rabi_ribi_ids[::-1]:
+            last_received_item_index = self.rr_interface.get_last_received_item_index()
+            remaining_items = self.items_received_rabi_ribi_ids[last_received_item_index:]
+            for item_id in remaining_items:
                 if item_id != -1:
                     return not self.rr_interface.does_player_have_item_id(item_id)
         return False
@@ -537,7 +537,6 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         self.current_room = (-1, -1)
         self.state_giving_item = False
         self.collected_eggs = set()
-        self.last_received_item_index = -1
         self.seed_name = None
         self.slot_data = None
 

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -621,10 +621,11 @@ async def rabi_ribi_watcher(ctx: RabiRibiContext):
             if cur_time - ctx.time_since_last_item_obtained > 7:
                 ctx.rr_interface.remove_exclamation_point_from_inventory()
 
-            if ctx.rr_interface.get_number_of_eggs_collected() >= 5:
-                ctx.finished_game = True
-                await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
-                
+            if ctx.slot_data:
+                number_of_easter_eggs = ctx.slot_data["number_of_easter_eggs"] if "number_of_easter_eggs" in ctx.slot_data else 5
+                if ctx.slot_data and ctx.rr_interface.get_number_of_eggs_collected() >= number_of_easter_eggs:
+                    ctx.finished_game = True
+                    await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
 
         except Exception as err:  # Rabi Ribi Process closed?
             logger.warning("*******************************")

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -623,8 +623,8 @@ async def rabi_ribi_watcher(ctx: RabiRibiContext):
                 ctx.rr_interface.remove_exclamation_point_from_inventory()
 
             if ctx.slot_data:
-                number_of_easter_eggs = ctx.slot_data["number_of_easter_eggs"] if "number_of_easter_eggs" in ctx.slot_data else 5
-                if ctx.slot_data and ctx.rr_interface.get_number_of_eggs_collected() >= number_of_easter_eggs:
+                required_egg_count = ctx.slot_data["required_egg_count"] if "required_egg_count" in ctx.slot_data else 5
+                if ctx.slot_data and ctx.rr_interface.get_number_of_eggs_collected() >= required_egg_count:
                     ctx.finished_game = True
                     await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])
 

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -287,12 +287,13 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
     async def set_received_rabi_ribi_item_ids(self):
         async with self.critical_section_lock:
             self.items_received_rabi_ribi_ids = []
+            #  Subtract 30 since those are reserved for shop and super / hyper attack modes
             potion_ids = {
-                ItemName.attack_up: 193, # Subtract 30, as those IDs are reserved for super / hyper attack modes
-                ItemName.mp_up: 287,
-                ItemName.regen_up: 351,
-                ItemName.hp_up: 159,
-                ItemName.pack_up: 415
+                ItemName.attack_up: 223 - 30,
+                ItemName.mp_up: 287 - 30,
+                ItemName.regen_up: 351 - 30,
+                ItemName.hp_up: 159 - 30,
+                ItemName.pack_up: 415 - 30
             }
 
             for network_item in self.items_received:

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -315,6 +315,11 @@ class RabiRibiMemoryIO():
         """
         data = self.rr_mem.read_bytes(self.rr_mem.base_address + OFFSET_EGG_START, EGG_ARRAY_LENGTH)
         eggs: List[Tuple[int, int, int]] = list(struct.iter_unpack('3h', data))
+
+        # Check if the player has 80 eggs
+        if (0,0,0) not in eggs:
+            return eggs
+
         egg_count = eggs.index((0,0,0))
 
         if egg_count >= 0:

--- a/worlds/rabi_ribi/docs/en_Rabi-Ribi.md
+++ b/worlds/rabi_ribi/docs/en_Rabi-Ribi.md
@@ -13,8 +13,8 @@ would be expected to in the vanilla game.
 
 ## What is the goal of Rabi-Ribi in Archipelago
 
-The goal of Rabi-Ribi is to find 5 Easter Egg items shuffled throughout Rabi Rabi Island. Collecting the fifth Easter Egg
-will complete your seed.
+The goal of Rabi-Ribi is to find Easter Eggs  shuffled throughout Rabi Rabi Island. Collecting
+all of the Easter Eggs will complete your seed.
 
 Setting the goal to completing the main story is not currently implemented, as the game is beatable with no items.
 

--- a/worlds/rabi_ribi/docs/en_Rabi-Ribi.md
+++ b/worlds/rabi_ribi/docs/en_Rabi-Ribi.md
@@ -13,7 +13,7 @@ would be expected to in the vanilla game.
 
 ## What is the goal of Rabi-Ribi in Archipelago
 
-The goal of Rabi-Ribi is to find Easter Eggs  shuffled throughout Rabi Rabi Island. Collecting
+The goal of Rabi-Ribi is to find Easter Eggs shuffled throughout Rabi Rabi Island. Collecting
 all of the Easter Eggs will complete your seed.
 
 Setting the goal to completing the main story is not currently implemented, as the game is beatable with no items.

--- a/worlds/rabi_ribi/entrance_shuffle.py
+++ b/worlds/rabi_ribi/entrance_shuffle.py
@@ -119,7 +119,7 @@ class MapAnalyzer(Analyzer):
 
     def verify_any_location_reachable(self, starting_variables, backward_exitable):
         """Verifies that at least one location is reachable without items."""
-        reachable, _, _, _ = super().verify_reachable_items(starting_variables, backward_exitable)
+        reachable, _, _, _ = self.verify_reachable_items(starting_variables, backward_exitable)
 
         # Convert item locations back to actual names
         item_location_reachable = {convert_existing_rando_name_to_ap_name(name[4:]) for name in reachable if name.startswith('LOC_')}
@@ -132,7 +132,7 @@ class MapAnalyzer(Analyzer):
         for item in self.data.must_be_reachable:
             variables[item] = True
 
-        reachable, _, _, _ = super().verify_reachable_items(variables, backward_exitable)
+        reachable, _, _, _ = self.verify_reachable_items(variables, backward_exitable)
 
         # Convert item locations back to actual names
         item_location_reachable = {convert_existing_rando_name_to_ap_name(name[4:]) for name in reachable if name.startswith('LOC_')}

--- a/worlds/rabi_ribi/existing_randomizer/maptemplates/template_constraints.txt
+++ b/worlds/rabi_ribi/existing_randomizer/maptemplates/template_constraints.txt
@@ -671,6 +671,8 @@
             ))
         )
     ",
+    }
+    {
     "edge": "RIVERBANK_UNDERGROUND -> RIVERBANK_LOWER_LEFT",
     "prereq": "
         FIRE_ORB & (

--- a/worlds/rabi_ribi/items.py
+++ b/worlds/rabi_ribi/items.py
@@ -1,5 +1,5 @@
 """This module represents item definitions for Rabi-Ribi"""
-from typing import Dict, List, NamedTuple, Optional, Set
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
 from BaseClasses import Item, ItemClassification
 from .existing_randomizer.dataparser import RandomizerData
@@ -131,6 +131,14 @@ item_data_table : Dict[str, RabiRibiItemData] = {
     **trap_table
 }
 
+filler_items : Dict[str, int] = {
+    ItemName.hp_up: 25,
+    ItemName.mp_up: 25,
+    ItemName.attack_up: 20,
+    ItemName.pack_up: 15,
+    ItemName.regen_up: 15
+}
+
 item_table: Dict[str, int] = {name: data.code for name, data in item_data_table.items() if data.code is not None }
 
 lookup_item_id_to_name: Dict[int, str] = {data.code: item_name for item_name, data in item_data_table.items() if data.code}
@@ -184,25 +192,21 @@ def get_base_item_list(options: RabiRibiOptions, data: RandomizerData) -> List[s
     item_names: List[str] = data.to_shuffle
     item_names += data.included_additional_items
     item_names.sort()
-    # Use a set amount of easter eggs
-    for _ in range(options.number_of_easter_eggs.value):
-        item_list.append("Easter Egg")
 
     for item in item_names:
-        # If we want to include the item, convert to the AP item id.
-        # Otherwise, pass and dont include it.
+        # Remove Eggs and Potions, to be used as filler items
         if item.startswith("EGG"):
             pass
         elif item.startswith("ATK_UP"):
-            item_list.append("Attack Up")
+            pass
         elif item.startswith("HP_UP"):
-            item_list.append("HP Up")
+            pass
         elif item.startswith("MP_UP"):
-            item_list.append("MP Up")
+            pass
         elif item.startswith("PACK_UP"):
-            item_list.append("Pack Up")
+            pass
         elif item.startswith("REGEN_UP"):
-            item_list.append("Regen Up")
+            pass
         else:
             # Format the item string and then add to the item list
             item_list.append(convert_existing_rando_name_to_ap_name(item))

--- a/worlds/rabi_ribi/items.py
+++ b/worlds/rabi_ribi/items.py
@@ -171,7 +171,7 @@ shufflable_gift_items_plurkwood = {
     ItemName.p_hairpin
 }
 
-def get_base_item_list(data: RandomizerData) -> List[str]:
+def get_base_item_list(options: RabiRibiOptions, data: RandomizerData) -> List[str]:
     """
     Get the base list of items in the game.
     No options are configurable at the moment.
@@ -185,7 +185,7 @@ def get_base_item_list(data: RandomizerData) -> List[str]:
     item_names += data.included_additional_items
     item_names.sort()
     # Use a set amount of easter eggs
-    for _ in range(5):
+    for _ in range(options.number_of_easter_eggs.value):
         item_list.append("Easter Egg")
 
     for item in item_names:

--- a/worlds/rabi_ribi/logic_helpers.py
+++ b/worlds/rabi_ribi/logic_helpers.py
@@ -14,9 +14,9 @@ from .utility import convert_existing_rando_name_to_ap_name
 
 def has_3_magic_types(state: CollectionState, player: int):
     """Player has at least 3 types of magic"""
-    # While the player can buy Healing Staff from the shop,
-    # that would imply they can access town and already access the item menu.
-    return state.count_group_unique("Magic", player) + 1 >= 3
+    # If playing with more than 5 Easter Eggs, Rainbow Shot could be used as a magic type
+    rainbow_shot = 1 if state.has(ItemName.easter_egg, player, count = 5) else 0
+    return state.count_group_unique("Magic", player) + rainbow_shot + 1 >= 3
 
 def has_item_menu(state: CollectionState, player: int, options):
     """Player has access to the item menu"""

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -23,6 +23,16 @@ class CarrotShooterInLogic(Toggle):
     """
     display_name = "Carrot Shooter In Logic"
 
+class NumberOfEasterEggs(Range):
+    """
+    The number of easter eggs required to beat the game. Note that you will receive
+    the Rainbow Shot after 5 eggs no matter how many eggs are selected.
+    """
+    display_name = "Number of Easter Eggs"
+    default = 5
+    range_start = 1
+    range_end = 80
+
 class EncourageEggsInLateSpheres(Toggle):
     """
     If set to true, the randomizer logic will attempt to place eggs in later spheres
@@ -237,6 +247,7 @@ class RabiRibiOptions(PerGameCommonOptions):
     event_warps_in_logic: EventWarpsInLogic
 
     attack_mode: AttackMode
+    number_of_easter_eggs: NumberOfEasterEggs
     encourage_eggs_in_late_spheres: EncourageEggsInLateSpheres
 
     randomize_hammer: RandomizeHammer

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass
 from Options import PerGameCommonOptions, Choice, Range, Toggle, DeathLink
 
 class OpenMode(Toggle):
-    """Gain access to Chapter 1 areas without needing to complete the prologue"""
+    """
+    Gain access to Chapter 1 areas without needing to complete the prologue.
+    It is highly recommended to leave this enabled.
+    """
     display_name = "Open Mode"
     default = True
 

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -23,15 +23,26 @@ class CarrotShooterInLogic(Toggle):
     """
     display_name = "Carrot Shooter In Logic"
 
-class NumberOfEasterEggs(Range):
+class MaxNumberOfEasterEggs(Range):
     """
-    The number of easter eggs required to beat the game. Note that you will receive
-    the Rainbow Shot after 5 eggs no matter how many eggs are selected.
+    Maximum possible number of Easter Eggs that will be in the item pool.
+    If fewer available locations exist in the pool than this number, the number of available locations will be used instead.
+    Required Percentage of Easter Eggs will be calculated based off of that number.
     """
-    display_name = "Number of Easter Eggs"
-    default = 5
+    display_name = "Max Number of Easter Eggs"
     range_start = 1
     range_end = 80
+    default = 5
+
+class PercentageOfEasterEggs(Range):
+    """
+    What percentage of Easter Eggs are required to beat the game. Note that you will receive
+    the Rainbow Shot after 5 eggs no matter how many eggs are required.
+    """
+    display_name = "Required Percentage of Easter Eggs"
+    range_start = 1
+    range_end = 100
+    default = 100
 
 class EncourageEggsInLateSpheres(Toggle):
     """
@@ -233,7 +244,12 @@ class ShuffleStartLocation(Toggle):
 @dataclass
 class RabiRibiOptions(PerGameCommonOptions):
     """Rabi Ribi Options Definition"""
+    max_number_of_easter_eggs: MaxNumberOfEasterEggs
+    percentage_of_easter_eggs: PercentageOfEasterEggs
+    encourage_eggs_in_late_spheres: EncourageEggsInLateSpheres
+
     open_mode: OpenMode
+    attack_mode: AttackMode
     knowledge: Knowledge
     trick_difficulty: TrickDifficulty
     block_clips_required: BlockClipsRequired
@@ -245,10 +261,6 @@ class RabiRibiOptions(PerGameCommonOptions):
     underwater_without_water_orb: UnderwaterWithoutWaterOrb
     carrot_shooter_in_logic: CarrotShooterInLogic
     event_warps_in_logic: EventWarpsInLogic
-
-    attack_mode: AttackMode
-    number_of_easter_eggs: NumberOfEasterEggs
-    encourage_eggs_in_late_spheres: EncourageEggsInLateSpheres
 
     randomize_hammer: RandomizeHammer
     randomize_gift_items: RandomizeGiftItems

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -28,9 +28,11 @@ class CarrotShooterInLogic(Toggle):
 
 class MaxNumberOfEasterEggs(Range):
     """
-    Maximum possible number of Easter Eggs that will be in the item pool.
-    If fewer available locations exist in the pool than this number, the number of available locations will be used instead.
-    Required Percentage of Easter Eggs will be calculated based off of that number.
+    The maximum number of Easter Eggs that will be in the item pool.
+    If fewer available locations exist in the pool than this number, random potions will be removed to make space.
+    By default, 26 eggs can be placed before potions are removed;
+    with all locations enabled, there is space for 57 eggs.
+    Required Percentage of Easter Eggs will be calculated based off of this number.
     """
     display_name = "Max Number of Easter Eggs"
     range_start = 1


### PR DESCRIPTION
Adds two new options:
- `max_number_of_easter_eggs`: The maximum number of Easter Eggs the seed will attempt to add to the world. If there's not enough locations, the generator will lower this number.
  - Admittedly, this shouldn't happen currently. I moved all 100 potions to be filler items, so the generator will place them (the potions) only if there's enough space.
- `percentage_of_easter_eggs`: The percentage of Easter Eggs needed to beat the game.
Closes #23 

Additional Fixes:
- Fixed #37 
- Fixed #16 
- Fixed #39 
- Fixed a typo in constraint `riverbank_lower_exit_fireorb`, which caused only the exit part of the edge replacements to be loaded
- Fixed a `ValueError` exception being thrown when the player has 80 Easter Eggs.