### PR TITLE
Add missing events to the event list

### DIFF
--- a/worlds/rabi_ribi/items.py
+++ b/worlds/rabi_ribi/items.py
@@ -171,6 +171,9 @@ recruit_table: Set[str] = {
 
 event_table: Set[str] = {
     *recruit_table,
+    ItemName.cocoa_1,
+    ItemName.kotri_1,
+    ItemName.kotri_2,
     ItemName.rumi_recruit,
     ItemName.miriam_recruit,
     ItemName.irisu_recruit,


### PR DESCRIPTION
Forgot that Cocoa and Kotri had non-recruitment events to add.
