### PR TITLE
Fix deathlink sending extra death at high health

### DIFF
--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -142,6 +142,19 @@ class RabiRibiMemoryIO():
             return False
         return True
 
+    def _read_4_byte_bool_raw(self, address):
+        """
+        Read a word at the specified address, and interpret it as a bool
+
+        :int address: the address to read data from.
+        :returns: The data represented as a float.
+        """
+        data = self.rr_mem.read_bytes(address, 4)
+        if (struct.unpack("i", data)[0] == 0):
+            return False
+        return True
+        
+
     def read_player_tile_position(self):
         """
         Read the player (area_id,x,y) and convert it to tile (area_id,x,y).
@@ -361,7 +374,8 @@ class RabiRibiMemoryIO():
         """
         True if the player's health is at 0
         """
-        return not self._read_4_byte_bool(OFFSET_MAX_HEALTH)
+        player_state_health_address = self._read_int(OFFSET_PLAYER_STATE) + OFFSET_PLAYER_STATE_HEALTH 
+        return not self._read_4_byte_bool_raw(player_state_health_address)
 
     def set_player_health_to_zero(self):
         """


### PR DESCRIPTION
Fix an issue where receiving a deathlink would send an additional deathlink back to the server when the current health was high.
The issue was caused due to reading the "visible" health value when checking the player's current health, but the visible health slides to the new value, meaning the deathlink buffer was cleared before the "visible" health fully dropped to 0.

## What is this fixing or adding?

Fixing #49 

## How was this tested?

Verified issue occurs at 290 health and confirmed extra death is no longer being sent

## If this makes graphical changes, please attach screenshots.
