### PR TITLE
Bandaid fix for failed world generation when using include_post_game = true and include_warp_destination = false

### DIFF
--- a/worlds/rabi_ribi/regions.py
+++ b/worlds/rabi_ribi/regions.py
@@ -180,7 +180,8 @@ class RegionHelper:
         if not self.options.include_plurkwood and not ut_helpers.should_regenerate_seed_for_universal_tracker(self.world):
             self.unreachable_regions.update(plurkwood_regions)
 
-        if not self.options.include_warp_destination:
+        if not self.options.include_warp_destination and not self.options.include_post_game:
+            #TODO Warn users that warp destination is included, OR split the regions from the locations
             self.unreachable_regions.update(warp_destination_regions)
 
         if not self.options.include_post_game:


### PR DESCRIPTION
**This change is untested**

This change aims to fix a key_value error when using include_post_game = true and include_warp_destination = false.
A proper fix would be to split the regions from the checks, however a more appropriate solution would to be merging the two settings (+include_post_irisu) into a max_required_story setting. This would force the 3 locations in warp destination to be in logic for the existing include_post_game and include_post_irisu.