### PR TITLE
Inital addition of remote eggs (Breaks YAMLS)

### DIFF
--- a/worlds/rabi_ribi/__init__.py
+++ b/worlds/rabi_ribi/__init__.py
@@ -124,7 +124,8 @@ class RabiRibiWorld(World):
         self.randomizer_data = RandomizerData(self.existing_randomizer_args)
 
         # Will be configurable later, but for now always force eggs to be local
-        self.options.local_items.value.add(ItemName.easter_egg)
+        if not self.options.allow_remote_easter_eggs:
+            self.options.local_items.value.add(ItemName.easter_egg)
 
         # Force consumable items to be local, as the player may need to pick them up multiple times
         self.options.local_items.value.update(item_groups["Consumables"])

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -151,6 +151,7 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         self.current_room: Tuple[int, int] = (-1, 1)
         self.state_giving_item = False
         self.collected_eggs: Set[Tuple[int,int,int]] = set()
+        self.received_eggs: Set[Tuple[int, int, int]] = set()
         self.seed_name = None
         self.slot_data = None
 
@@ -380,7 +381,7 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
                 ItemName.hp_up: 159 - 30,
                 ItemName.pack_up: 415 - 30
             }
-
+            egg_count = 0
             for network_item in self.items_received:
                 item_name = self.item_names.lookup_in_game(network_item.item)
                 if item_name == ItemName.nothing:
@@ -389,13 +390,12 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
                     self.items_received_rabi_ribi_ids.append(potion_ids[item_name])
                     potion_ids[item_name] -= 1
                 elif item_name == ItemName.easter_egg:
-                    if network_item.player == self.slot:
-                        location_name = self.location_names.lookup_in_game(network_item.location)
-                        egg_coordinates = self.ap_location_name_to_location_coordinates[location_name]
-                        self.collected_eggs.add(egg_coordinates)
+                    self.received_eggs.add((10, 1, egg_count))
+                    egg_count += 1
                 else:
                     self.items_received_rabi_ribi_ids.append(
                         int(self.item_name_to_rabi_ribi_item_id[item_name]))
+                
 
     def is_item_queued(self):
         """
@@ -440,6 +440,12 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
                     if location_id not in self.locations_checked:
                         self.locations_checked.add(location_id)
                         await self.send_msgs([{"cmd": 'LocationChecks', "locations": self.locations_checked}])
+
+    async def add_remote_eggs(self):
+        """
+        Adds eggs recieved from other worlds
+        """
+        self.rr_interface.add_missing_eggs(self.collected_eggs, self.received_eggs)
 
     async def update_player_location(self):
         area_id, x, y = self.rr_interface.read_player_tile_position()
@@ -512,7 +518,9 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
             (cur_time - self.time_since_last_costume_menu >= 2) and
             not self.rr_interface.is_player_frozen() and
             len(self.deathlink_buffer) == 0 and
-            self.is_item_queued()
+            (self.is_item_queued() or
+             self.received_eggs.difference(self.collected_eggs)
+            )
         )
 
     def in_state_where_should_open_warp_menu(self):
@@ -638,6 +646,7 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         self.current_room = (-1, -1)
         self.state_giving_item = False
         self.collected_eggs = set()
+        self.received_eggs = set()
         self.seed_name = None
         self.slot_data = None
 
@@ -715,6 +724,7 @@ async def rabi_ribi_watcher(ctx: RabiRibiContext):
 
             if ctx.in_state_where_can_give_items():
                 await ctx.give_item()
+                await ctx.add_remote_eggs()
 
             # Fallback if player collected items while the client was disconnected.
             #   Make sure the player never has an exclamation point in their inventory.

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -10,7 +10,7 @@ in realtime. This is used to:
 """
 import asyncio
 import struct
-from typing import List, Tuple
+from typing import List, Tuple, Set
 
 from pymem import pymem
 
@@ -369,3 +369,14 @@ class RabiRibiMemoryIO():
         """
         player_state_health_address = self._read_int(OFFSET_PLAYER_STATE) + OFFSET_PLAYER_STATE_HEALTH
         self.rr_mem.write_int(player_state_health_address, 0)
+
+    def add_missing_eggs(self, current_eggs: Set[Tuple[int, int, int]], eggs_to_add: Set[Tuple[int, int, int]]):
+        """
+        Adds Easter Eggs to a player's inventory, if they are not already added.
+        """
+        eggs_to_patch = eggs_to_add.difference(current_eggs)
+        if(not eggs_to_patch):
+            return
+        current_egg_offset = len(current_eggs) * 3 * 2
+        data = b''.join(struct.pack(f"<3h", *egg) for egg in eggs_to_patch)
+        self.rr_mem.write_bytes(self.rr_mem.base_address + OFFSET_EGG_START + current_egg_offset, data, len(data))

--- a/worlds/rabi_ribi/options.py
+++ b/worlds/rabi_ribi/options.py
@@ -47,6 +47,13 @@ class MaxNumberOfEasterEggs(Range):
     range_end = 80
     default = 5
 
+class AllowRemoteEasterEggs(Toggle):
+    """
+    Defines if Easter Eggs can be located in other player's worlds.
+    If false, all Easter Eggs will be local
+    """
+    display_name = "Allow Remote Easter Eggs"
+
 class PercentageOfEasterEggs(Range):
     """
     What percentage of Easter Eggs are required to beat the game. Note that you will receive
@@ -259,6 +266,7 @@ class RabiRibiOptions(PerGameCommonOptions):
     """Rabi Ribi Options Definition"""
     max_number_of_easter_eggs: MaxNumberOfEasterEggs
     percentage_of_easter_eggs: PercentageOfEasterEggs
+    allow_remote_easter_eggs: AllowRemoteEasterEggs
     encourage_eggs_in_late_spheres: EncourageEggsInLateSpheres
 
     open_mode: OpenMode


### PR DESCRIPTION
- Added new option: allow_remote_easter_eggs

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
This adds an option to enable Easter Eggs to appear in other players worlds. 
When the player receives an Easter egg, it is added to the Easter Egg array in game memory with the following specifications:
 - location_id: 10, this prevents the egg counting towards egg collection for any of the maps
 - x_coord: 1, to enable the game to see the easter egg
 - y_coord: 0-N, to create uniqueness between each received egg.

## How was this tested?
Some light testing has been done to verify the new feature works. The game correctly adds received eggs.

## If this makes graphical changes, please attach screenshots.
