### PR TITLE
General fixes to warps

### DIFF
--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -521,7 +521,8 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
             (cur_time - self.time_since_last_save_menu >= 2) and
             not self.rr_interface.is_player_frozen() and
             len(self.deathlink_buffer) == 0 and
-            self.is_item_queued()
+            self.is_item_queued() and
+            not self.rr_interface.is_in_event()
         )
 
     def in_state_where_should_open_warp_menu(self):
@@ -530,7 +531,9 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
             (cur_time - self.time_since_last_paused >= .5) and
             not self.rr_interface.is_player_frozen() and
             not self.is_item_queued() and
-            self.rr_interface.get_item_state(STRANGE_BOX_ITEM_ID) == -1
+            self.rr_interface.get_item_state(STRANGE_BOX_ITEM_ID) == -1 and
+            not self.rr_interface.is_in_event() and 
+            self.rr_interface.read_player_tile_position()[0] != 8 #Warp Destination
         )
 
     async def watch_for_menus(self):
@@ -556,6 +559,7 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         # Reenable the Strange Box first.
         self.rr_interface.set_item_state(STRANGE_BOX_ITEM_ID, 1)
         self.rr_interface.open_warp_menu()
+        self.rr_interface.set_darkness_off()
 
     def in_deathlink_eligible_state(self):
         cur_time = time.time()

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -19,6 +19,7 @@ from CommonClient import logger
 OFFSET_AREA_ID = int(0xD9CF88)
 OFFSET_PLAYER_X = int(0x0103469C)
 OFFSET_PLAYER_Y = int(0x013AFDB4)
+OFFSET_IS_DARK = int(0x16E684C)
 OFFSET_GIVE_ITEM_FUNC = int(0x15A90)
 OFFSET_PLAYER_FROZEN = int(0x1031DDC)
 OFFSET_ITEM_MAP = int(0xDFFB3C)
@@ -33,7 +34,8 @@ OFFSET_IN_WARP_MENU = int(0x16E5BB8)
 OFFSET_IN_COSTUME_MENU = int(0x16E6B20)
 OFFSET_IN_SAVE_MENU = int(0xD2DA50)
 OFFSET_CURRENT_WARP_ID = int(0x016E6D08)
- # returns a memory address where various state is stored
+OFFSET_EVENT_ACTIVE = int(0x16E4F30)
+# returns a memory address where various state is stored
 OFFSET_PLAYER_STATE = int(0x1682364)
 # offset from the address from OFFSET_PLAYER_STATE
 OFFSET_PLAYER_STATE_HEALTH = int(0x4E0)
@@ -376,6 +378,12 @@ class RabiRibiMemoryIO():
         True if the player is currently selecting a costume
         """
         return self._read_4_byte_bool(OFFSET_IN_COSTUME_MENU)
+    
+    def is_in_event(self) -> bool:
+        """
+        True if the player is currently in an event (ex. bossfight, dialogue)
+        """
+        return self._read_4_byte_bool(OFFSET_EVENT_ACTIVE)
 
     def has_zero_health(self) -> bool:
         """
@@ -390,3 +398,9 @@ class RabiRibiMemoryIO():
         """
         player_state_health_address = self._read_int(OFFSET_PLAYER_STATE) + OFFSET_PLAYER_STATE_HEALTH
         self.rr_mem.write_int(player_state_health_address, 0)
+
+    def set_darkness_off(self):
+        """
+        Sets the darkness flag to 0, thereby disabling it if enabled
+        """
+        self.rr_mem.write_int(self.rr_mem.base_address + OFFSET_IS_DARK, 0)


### PR DESCRIPTION
Closes #34 
Adds new check for player state: `is_in_event`
Prevents players from receiving items during cutscenes and bossfights (untested)
Note: this implementation just disables darkness after opening the warp menu. It might be wise to instead spawn a thread which watches until the warp is executed to disable darkness. This would probably be useful in addressing bad teleports (issue #48).