### PR TITLE
Fix Several Logic Errors

### DIFF
--- a/worlds/rabi_ribi/existing_randomizer/constraints.txt
+++ b/worlds/rabi_ribi/existing_randomizer/constraints.txt
@@ -1358,7 +1358,7 @@
 
 {
 "item": "HP_UP_VOLCANIC",
-"from_location": "VOLCANIC_BEACH_ENTRANCE",
+"from_location": "VOLCANIC_MAIN",
 "entry_prereq": "EXPLOSIVES_ENEMY",
 "exit_prereq": "NONE",
 }
@@ -1972,7 +1972,7 @@
 
 {
 "item": "EGG_VOLCANIC_BOMB_BUNNIES",
-"from_location": "VOLCANIC_BEACH_ENTRANCE",
+"from_location": "VOLCANIC_MAIN",
 "entry_prereq": "NONE",
 "exit_prereq": "NONE",
 }

--- a/worlds/rabi_ribi/existing_randomizer/constraints_graph.txt
+++ b/worlds/rabi_ribi/existing_randomizer/constraints_graph.txt
@@ -1711,11 +1711,6 @@ DARKNESS & (
 }
 
 {
-"edge": "SNOWLAND_LAKE -> SNOWLAND_MID",
-"prereq": "NONE",
-}
-
-{
 "edge": "SNOWLAND_MID -> SNOWLAND_QUICK_BARRETTE_ROOM",
 "prereq": "NONE",
 }

--- a/worlds/rabi_ribi/logic_helpers.py
+++ b/worlds/rabi_ribi/logic_helpers.py
@@ -183,12 +183,12 @@ def can_recruit_pandora(state: CollectionState, player: int):
 def can_recruit_nieve(state: CollectionState, player: int):
     """Player can recruit Nieve"""
     return state.can_reach(LocationName.palace_level_5, "Region", player) and \
-        state.can_reach(LocationName.icy_summit_main, "Region", player)
+        state.can_reach(LocationName.icy_summit_nixie, "Region", player)
 
 def can_recruit_nixie(state: CollectionState, player: int):
     """Player can recruit Nixie"""
     return state.can_reach(LocationName.palace_level_5, "Region", player) and \
-        state.can_reach(LocationName.icy_summit_main, "Region", player)
+        state.can_reach(LocationName.icy_summit_nixie, "Region", player)
 
 def can_recruit_aruraune(state: CollectionState, player: int):
     """Player can recruit Aruraune"""


### PR DESCRIPTION
## What is this fixing or adding?
Fixes #62 

## How was this tested?
Generated 10,000 seeds with a fuzzer (https://github.com/Eijebong/Archipelago-fuzzer)
There were 24 failures, consistent with previous runs.
Of the 24 failures, 19 were with minimal accessibility, 4 failed due to a small initial sphere, and 1 failed to generate a valid map in 1,000 attempts.

Note for others using the fuzzer: I set the following options to static using a meta YAML with `-m`:
```yaml
Rabi-Ribi:
  apply_beginner_mod: false
  open_mode: true
  randomize_hammer: true
  encourage_eggs_in_late_spheres: false
```
This avoids many ignored YAMLs due to conflicting settings.

## If this makes graphical changes, please attach screenshots.
N/A