### PR TITLE
Fixes for Issues Found in Post-Game Testing

### DIFF
--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -16,13 +16,12 @@ jobs:
       run: mkdir artifacts
       
     - name: Compress APWorld Folder
-      run: zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
-      
-    - name: Change File Extension
-      run: mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
+      run: |
+        zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
+        mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4.6.2
       with:
         name: compressed-data
-        path: ./artifacts/rabi-ribi.apworld
+        path: ./artifacts/rabi_ribi.apworld

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -16,10 +16,9 @@ jobs:
       run: mkdir artifacts
       
     - name: Compress APWorld Folder
-      run: zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
-
-    - name: Change File Extension
-      run: mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
+      run: |
+        zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
+        mv ./artifacts/raib_ribi.zip ./artifacts/rabi_ribi.apworld
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -16,9 +16,10 @@ jobs:
       run: mkdir artifacts
       
     - name: Compress APWorld Folder
-      run: |
-        zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
-        mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
+      run: zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
+      
+    - name: Change File Extension
+      run: mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Create Artifacts Folder
       run: mkdir artifacts
-      
+
     - name: Compress APWorld Folder
       run: |
         cd ./worlds

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -15,7 +15,6 @@ jobs:
     - name: Create Artifacts Folder
       run: mkdir artifacts
       
-      
     - name: Compress APWorld Folder
       run: |
         cd ./worlds

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -15,10 +15,12 @@ jobs:
     - name: Create Artifacts Folder
       run: mkdir artifacts
       
+      
     - name: Compress APWorld Folder
       run: |
-        zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
-        mv ./artifacts/raib_ribi.zip ./artifacts/rabi_ribi.apworld
+        cd ./worlds
+        zip -r ../artifacts/rabi_ribi.zip ./rabi_ribi
+        mv ../artifacts/rabi_ribi.zip ../artifacts/rabi_ribi.apworld
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4.6.2
       with:
-        name: compressed-data
+        name: Rabi-Ribi APWorld
         path: ./artifacts/rabi_ribi.apworld

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -16,9 +16,10 @@ jobs:
       run: mkdir artifacts
       
     - name: Compress APWorld Folder
-      run: |
-        zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
-        mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
+      run: zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
+
+    - name: Change File Extension
+      run: mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -9,6 +9,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: Set env
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@v5.0.0
 
@@ -21,8 +24,13 @@ jobs:
         zip -r ../artifacts/rabi_ribi.zip ./rabi_ribi
         mv ../artifacts/rabi_ribi.zip ../artifacts/rabi_ribi.apworld
 
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v4.6.2
+    - name: Add to Release
+      uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
       with:
-        name: Rabi-Ribi APWorld
-        path: ./artifacts/rabi_ribi.apworld
+        draft: true
+        prerelease: false
+        name: ${{ env.RELEASE_VERSION }}
+        files: |
+          artifacts/rabi_ribi.apworld
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package_apworld.yml
+++ b/.github/workflows/package_apworld.yml
@@ -1,0 +1,27 @@
+name: Package APWorld
+
+on:
+  push:
+    tags:
+      - 'beta-*.*.*'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5.0.0
+
+    - name: Create Artifacts Folder
+      run: mkdir artifacts
+      
+    - name: Compress APWorld Folder
+      run: |
+        zip -r ./artifacts/raib_ribi.zip ./worlds/rabi_ribi
+        mv ./artifacts/raib_ribi.zip ./artifacts/raib_ribi.apworld
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: compressed-data
+        path: ./artifacts/rabi-ribi.apworld

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -24,6 +24,7 @@ from worlds.rabi_ribi.client.memory_io import RabiRibiMemoryIO
 from worlds.rabi_ribi.items import event_table, consumable_table
 from worlds.rabi_ribi.locations import all_locations
 from worlds.rabi_ribi.names import ItemName
+from worlds.rabi_ribi.options import AttackMode
 from worlds.rabi_ribi.utility import (
     CLIENT_VERSION,
     load_text_file,
@@ -71,6 +72,13 @@ class RabiRibiCommandProcessor(TrackerCommandProcessor): # type: ignore
     def _cmd_disable_crosswarp_check(self) -> None:
         """Disables crosswarp check for Strange Box warping"""
         self.ctx.disable_crosswarp()
+
+    def _cmd_attack_mode(self, mode: str = "") -> None:
+        """Updates the player's attack mode. Options are normal, super, or hyper"""
+        if mode is None or mode not in AttackMode.options:
+            logger.info("Provide an attack mode using /attack_mode [mode]. Available options for mode are normal, super, or hyper")
+            return
+        self.ctx.set_attack_mode_flag(mode)
 
     if tracker_loaded:
         @mark_raw
@@ -207,6 +215,7 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         self.has_died = False
 
         self.is_crosswarp_disabled = True
+        self.updated_attack_mode = None
 
     def make_gui(self):
         ui = super().make_gui()
@@ -672,6 +681,21 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
             logger.info(f"You have {len(self.collected_eggs)} Easter Eggs")
             logger.info(f"You need {required_egg_count} Easter Eggs total to beat the game")
 
+    def set_attack_mode_flag(self, mode) -> None:
+        """Flags the attack mode for update to a new setting."""
+        self.updated_attack_mode = AttackMode.from_any(mode)
+
+    def update_attack_mode(self) -> None:
+        """Updates the player's attack mode"""
+        MAX_ATTACK_UP_ID = 223
+        attack_mode = self.updated_attack_mode
+        self.updated_attack_mode = None
+        for i in range(0, 30):
+            if attack_mode == AttackMode.option_hyper or (i < 20 and attack_mode == AttackMode.option_super):
+                self.rr_interface.set_item_state(MAX_ATTACK_UP_ID - i, 1)
+            else:
+                self.rr_interface.set_item_state(MAX_ATTACK_UP_ID - i, 0)
+
     def reset_client_state(self):
         """
         Reset client back to default values
@@ -708,6 +732,7 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
         self.obtained_items_queue = asyncio.Queue()
 
         self.is_crosswarp_disabled = True
+        self.updated_attack_mode = None
     
     def disable_crosswarp(self):
         self.is_crosswarp_disabled = False
@@ -777,6 +802,9 @@ async def rabi_ribi_watcher(ctx: RabiRibiContext):
                 await ctx.give_item()
 
             ctx.handle_consumable_changes()
+
+            if ctx.updated_attack_mode is not None:
+                ctx.update_attack_mode()
 
             # Fallback if player collected items while the client was disconnected.
             #   Make sure the player never has an exclamation point in their inventory.

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -412,6 +412,9 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
             if not already_has_item:
                 await asyncio.sleep(1)
             await self.wait_until_out_of_item_receive_animation()
+        elif len(remaining_items) > 0:
+            # Update index to mark the player as not waiting for Nothing items
+            self.rr_interface.set_last_received_item_index(last_received_item_index + len(remaining_items))
 
     async def set_received_rabi_ribi_item_ids(self):
         async with self.critical_section_lock:

--- a/worlds/rabi_ribi/client/memory_io.py
+++ b/worlds/rabi_ribi/client/memory_io.py
@@ -32,7 +32,7 @@ OFFSET_SCENERIO_INDICATOR = int(0xE30880)
 OFFSET_IN_ITEM_GET_ANIMATION = int(0x1682ACA)
 OFFSET_IN_WARP_MENU = int(0x16E5BB8)
 OFFSET_IN_COSTUME_MENU = int(0x16E6B20)
-OFFSET_IN_SAVE_MENU = int(0xD2DA50)
+OFFSET_IN_SAVE_MENU = int(0x1664E04)
 OFFSET_CURRENT_WARP_ID = int(0x016E6D08)
  # returns a memory address where various state is stored
 OFFSET_PLAYER_STATE = int(0x1682364)
@@ -370,8 +370,8 @@ class RabiRibiMemoryIO():
 
         # When using the warp menu, the player cannot select to warp to their current location.
         # Since we're opening the menu in a random location, we need to set the current location to not be 0
-        # to allow warping to Starting Forest. We use Forgotten Cave 2, as it's an unnecessary warp.
-        self.rr_mem.write_int(self.rr_mem.base_address + OFFSET_CURRENT_WARP_ID, 13)
+        # to allow warping to Starting Forest. Using -1 allows all warps to be selected.
+        self.rr_mem.write_int(self.rr_mem.base_address + OFFSET_CURRENT_WARP_ID, -1)
 
     def get_collected_eggs(self) -> List[Tuple[int, int, int]]:
         """

--- a/worlds/rabi_ribi/existing_randomizer/backgroundrandomizer.py
+++ b/worlds/rabi_ribi/existing_randomizer/backgroundrandomizer.py
@@ -58,6 +58,10 @@ class BackgroundShuffler(object):
         ]
 
     def shuffle(self):
+        """
+        AP Change:
+            Fixed water in Hall of Memory.
+        """
         backgrounds = list(set(val for areaid, posindex, val in self.original_locations))
         new_backgrounds = list(backgrounds)
         if self.no_laggy_backgrounds:
@@ -95,6 +99,14 @@ class BackgroundShuffler(object):
             if areaid == 4 and posindex == to_tile_index(7,9): continue
             if areaid == 4 and posindex == to_tile_index(8,9): continue
             if areaid == 4 and posindex == to_tile_index(9,9): continue
+
+            # Fix for missing water in HoM
+            if areaid == 7 and posindex == to_tile_index(8,7): continue
+            if areaid == 7 and posindex == to_tile_index(9,7): continue
+            if areaid == 7 and posindex == to_tile_index(9,8): continue
+            if areaid == 7 and posindex == to_tile_index(10,7): continue
+            if areaid == 7 and posindex == to_tile_index(10,8): continue
+            if areaid == 7 and posindex == to_tile_index(10,9): continue
 
             # Fix for bug where you can't enter warps if it has computer room background.
             if allocation[val] == 64:
@@ -149,7 +161,6 @@ class BackgroundShuffler(object):
 
                 # Carrot boost doesn't work correctly for aurora palace whirl blocks template
                 if areaid == 3 and posindex == to_tile_index(1,9): continue
-                
 
             # Fix for Sysint1 background floating effect affecting constraints
             if allocation[val] == 65:

--- a/worlds/rabi_ribi/existing_randomizer/constraints.txt
+++ b/worlds/rabi_ribi/existing_randomizer/constraints.txt
@@ -1064,7 +1064,7 @@
 {
 "item": "REGEN_UP_SOUTH_RIVERBANK",
 "from_location": "RIVERBANK_UNDERGROUND",
-"entry_prereq": "DARKNESS & UNDERWATER & EXPLOSIVES",
+"entry_prereq": "DARKNESS & UNDERWATER & (CARROT_BOMB | (CARROT_SHOOTER & BOOST_BORING))",
 "exit_prereq": "NONE",
 }
 

--- a/worlds/rabi_ribi/existing_randomizer/dataparser.py
+++ b/worlds/rabi_ribi/existing_randomizer/dataparser.py
@@ -138,6 +138,7 @@ def define_pseudo_items():
 
         "BOOST": "BEACH_MAIN | (RUMI_DONUT & ITEM_MENU)",
         "BOOST_MANY": "ITEM_MENU & TOWN_SHOP",
+        "BOOST_BORING": "(BEACH_MAIN & BORING) | (RUMI_DONUT & ITEM_MENU)",
     }
 
 

--- a/worlds/rabi_ribi/existing_randomizer/utility.py
+++ b/worlds/rabi_ribi/existing_randomizer/utility.py
@@ -200,10 +200,16 @@ def mean(values):
 
 _potion_re = re.compile('^[A-Z]*_UP_')
 def is_potion(item_name):
-    return bool(_potion_re.match(item_name))
+    """
+    AP Change: Include items ending in UP as potions.
+    """
+    return bool(_potion_re.match(item_name)) or item_name.endswith('_UP')
 
 def is_egg(item_name):
-    return item_name!=None and item_name.startswith('EGG_')
+    """
+    AP Change: Include items named EASTER_EGG as eggs.
+    """
+    return item_name is not None and (item_name.startswith('EGG_') or item_name == 'EASTER_EGG')
 
 
 # Index Conversions

--- a/worlds/rabi_ribi/items.py
+++ b/worlds/rabi_ribi/items.py
@@ -171,6 +171,7 @@ recruit_table: Set[str] = {
 
 event_table: Set[str] = {
     *recruit_table,
+    ItemName.ashuri_2,
     ItemName.cocoa_1,
     ItemName.kotri_1,
     ItemName.kotri_2,

--- a/worlds/rabi_ribi/logic_helpers.py
+++ b/worlds/rabi_ribi/logic_helpers.py
@@ -155,8 +155,8 @@ def can_recruit_cocoa(state: CollectionState, player: int):
 
 def can_recruit_ashuri(state: CollectionState, player: int):
     """Player can recruit Ashuri"""
-    return state.can_reach(LocationName.riverbank_level3, "Region", player) and \
-        state.has("Chapter 1", player) and \
+    return state.has("Chapter 1", player) and \
+        state.has(ItemName.ashuri_2, player) and \
         state.can_reach(LocationName.spectral_west, "Region", player)
 
 def can_recruit_rita(state: CollectionState, player: int):
@@ -555,9 +555,9 @@ def convert_existing_rando_rule_to_ap_rule(existing_rule: object, player: int, r
             "Underwater": lambda state: can_navigate_underwater(state, player, options),
             "Underwater Without Water Orb": lambda state: can_navigate_underwater_without_water_orb(state, player, options),
             "Prologue Trigger": lambda state: can_move_out_of_prologue_areas(state, player, options),
-            "Cocoa 1": lambda state: can_reach_cocoa_1(state, player),
-            "Kotri 1": lambda state: can_reach_kotri_1(state, player),
-            "Ashuri 2": lambda state: can_reach_ashuri_2(state, player),
+            "Cocoa 1": lambda state: state.has(ItemName.cocoa_1, player),
+            "Kotri 1": lambda state: state.has(ItemName.kotri_1, player),
+            "Ashuri 2": lambda state: state.has(ItemName.ashuri_2, player),
             "Boss Ribbon": lambda state: can_reach_ribbon(state, player),
             "Difficulty Hard": lambda state: is_at_least_hard_difficulty(state, player, options),
             "Difficulty V Hard": lambda state: is_at_least_v_hard_difficulty(state, player, options),

--- a/worlds/rabi_ribi/logic_helpers.py
+++ b/worlds/rabi_ribi/logic_helpers.py
@@ -38,6 +38,14 @@ def can_use_boost_many(state: CollectionState, player: int, options):
     """Player can use the boost skill multiple times"""
     return state.has("Shop Access", player) and has_item_menu(state, player, options)
 
+def can_use_boost_boring(state: CollectionState, player: int, options):
+    """Player can use the boost skill or farm boost meter"""
+    return (state.has("Boost Unlock", player) and options.boring_tricks_required.value) or \
+        (
+            (state.has("Shop Access", player) or state.has(ItemName.rumi_donut, player)) and \
+            has_item_menu(state, player, options)
+        )
+
 def carrot_shooter_in_logic(state: CollectionState, player: int, options):
     """Player has Carrot Shooter and it's not out of logic by options"""
     return (options.carrot_shooter_in_logic.value or state.has(ItemName.glitched_logic, player)) and \
@@ -550,6 +558,7 @@ def convert_existing_rando_rule_to_ap_rule(existing_rule: object, player: int, r
             "Chapter 7": lambda state: state.has("Chapter 7", player),
             "Boost": lambda state: can_use_boost(state, player, options),
             "Boost Many": lambda state: can_use_boost_many(state, player, options),
+            "Boost Boring": lambda state: can_use_boost_boring(state, player, options),
             "Darkness": lambda state: can_navigate_darkness(state, player, options),
             "Darkness Without Light Orb": lambda state: can_navigate_darkness_without_light_orb(state, player, options),
             "Underwater": lambda state: can_navigate_underwater(state, player, options),

--- a/worlds/rabi_ribi/names/ItemName.py
+++ b/worlds/rabi_ribi/names/ItemName.py
@@ -93,6 +93,7 @@ wind_blessing = "Wind Blessing"
 fairies_flute = "Fairies Flute"
 
 # Recruit Definitions
+ashuri_2            = "Ashuri 2"
 cocoa_1             = "Cocoa 1"
 kotri_1             = "Kotri 1"
 kotri_2             = "Kotri 2"

--- a/worlds/rabi_ribi/regions.py
+++ b/worlds/rabi_ribi/regions.py
@@ -301,6 +301,7 @@ class RegionHelper:
         self.add_event("Boost Unlock", LocationName.beach_main)
         self.add_event("Shop Access", LocationName.town_shop)
 
+        self.add_event(ItemName.ashuri_2, LocationName.riverbank_level3)
         self.add_event(ItemName.cocoa_1, LocationName.forest_cocoa_room)
         self.add_event(ItemName.kotri_1, LocationName.park_kotri)
         self.add_event(ItemName.kotri_2, LocationName.graveyard_kotri,

--- a/worlds/rabi_ribi/utility.py
+++ b/worlds/rabi_ribi/utility.py
@@ -4,7 +4,7 @@ Utility used across the apworld
 import pkgutil, pkg_resources
 from Utils import Version
 
-CLIENT_VERSION = Version(1, 4, 0)
+CLIENT_VERSION = Version(1, 4, 1)
 rabi_ribi_base_id: int = 8350438193300
 
 def get_rabi_ribi_base_id() -> int:


### PR DESCRIPTION
## What is this fixing or adding?
Fixed issues found in #67 
- Fixed water rooms at the end of Hall of Memory missing water depending on the shuffled background.
- Added a command to set the player's attack mode
  - Technically a hotfix for some obscure tricks that may not be possible if the player's attack is too high, but likely useful for misconfigured YAMLs.
- Testing fix for Death Link and Strange Box warping randomly not working
  - Might be related to new check for save menu; @Peblo0110 suggested updating this address check to `0x1664e04`
- Fixed issue where map fixes for eggs in specific locations were not being applied.
- Strange Box Warp: Set current warp to an invalid warp when opening strange box warp menu.
  - Allows players to immediately warp to FC2 to complete their goal.

Fixed user reported issues:
- Fixed Cocoa 1, Kotri 1, and Ashuri 2 not being listed in the playthrough spoiler log.
- Marked Regen Up South Riverbank with Carrot Shooter and Boost as Boring.

## How was this tested?
- Validated fixes in a previously broken seed.
- Ran fuzzer over 10,000 seeds and verified there was no increase in failure rate.
