### PR TITLE
Remove redundant version constant

### DIFF
--- a/worlds/rabi_ribi/archipelago.json
+++ b/worlds/rabi_ribi/archipelago.json
@@ -1,6 +1,6 @@
 {
     "game": "Rabi-Ribi",
     "authors": ["PsyMarth", "Phie"],
-    "world_version": "1.4.2",
+    "world_version": "1.4.7",
     "minimum_ap_version": "0.6.4"
 }

--- a/worlds/rabi_ribi/client/client.py
+++ b/worlds/rabi_ribi/client/client.py
@@ -25,7 +25,6 @@ from worlds.rabi_ribi.locations import all_locations
 from worlds.rabi_ribi.names import ItemName
 from worlds.rabi_ribi.options import AttackMode
 from worlds.rabi_ribi.utility import (
-    CLIENT_VERSION,
     load_text_file,
     convert_existing_rando_name_to_ap_name
 )
@@ -158,7 +157,7 @@ class RabiRibiContext(TrackerGameContext): # type: ignore
 
     def make_gui(self):
         ui = super().make_gui()
-        ui.base_title = f"Rabi-Ribi Client v{CLIENT_VERSION.as_simple_string()}"
+        ui.base_title = f"Rabi-Ribi Client v{RabiRibiWorld.world_version.as_simple_string()}"
         if tracker_loaded:
             ui.base_title += f" | UT {UT_VERSION}"
 

--- a/worlds/rabi_ribi/utility.py
+++ b/worlds/rabi_ribi/utility.py
@@ -2,9 +2,7 @@
 Utility used across the apworld
 """
 import pkgutil, pkg_resources
-from Utils import Version
 
-CLIENT_VERSION = Version(1, 4, 6)
 rabi_ribi_base_id: int = 8350438193300
 
 def get_rabi_ribi_base_id() -> int:


### PR DESCRIPTION
## What is this fixing or adding?
* Removed the client version specified in `utility.py`
* Updated client to use `world_version` from the `archipelago.json` manifest in the title.
* Bumped version

## How was this tested?
* Ran Client locally