### PR TITLE
Disable minimal accessibility for fuzzing

### DIFF
--- a/meta/fuzz_rabi_ribi.yaml
+++ b/meta/fuzz_rabi_ribi.yaml
@@ -1,4 +1,5 @@
 Rabi-Ribi:
+  accessibility: full
   required_constraints: []
   fuzz_constraints:
     - option: rainbow_shot_in_logic


### PR DESCRIPTION
With the new feature to allow minimal accessibility to generate seeds where having access to all locations is not guaranteed with an all state, it is much more likely for generation to fail during fuzzing even with an empty world due to local only Easter Eggs.

Until Easter Eggs can be not local, I recommend disabling the fuzzing of minimal accessibility seeds and testing them locally (atm, around 1/500 fail)

## What is this fixing or adding?
- Disabled minimal accessibility for fuzzing

## How was this tested?
Fuzzing

## If this makes graphical changes, please attach screenshots.
N/A