### PR TITLE
Update Eggs and Magic Types to be Deprioritized

### DIFF
--- a/worlds/rabi_ribi/data/items.json
+++ b/worlds/rabi_ribi/data/items.json
@@ -3,7 +3,7 @@
     "id": 0,
     "name": "Easter Egg",
     "logic_key": "EASTER_EGG",
-    "classification": "progression_skip_balancing",
+    "classification": "progression_deprioritized_skip_balancing",
     "tags": ["Collectables"],
     "max_count": 80,
     "exclude_from_default_pool": true
@@ -102,7 +102,7 @@
     "id": 14,
     "name": "Chaos Rod",
     "logic_key": "CHAOS_ROD",
-    "classification": "progression",
+    "classification": "progression_deprioritized_skip_balancing",
     "tags": ["Upgrades", "Magic"]
   },
   {
@@ -165,7 +165,7 @@
     "id": 22,
     "name": "Sunny Beam",
     "logic_key": "SUNNY_BEAM",
-    "classification": "progression",
+    "classification": "progression_deprioritized_skip_balancing",
     "tags": ["Upgrades", "Magic"]
   },
   {
@@ -187,7 +187,7 @@
     "id": 25,
     "name": "Healing Staff",
     "logic_key": "HEALING_STAFF",
-    "classification": "progression",
+    "classification": "progression_deprioritized_skip_balancing",
     "tags": ["Upgrades", "Magic"]
   },
   {
@@ -201,7 +201,7 @@
     "id": 27,
     "name": "Explode Shot",
     "logic_key": "EXPLODE_SHOT",
-    "classification": "progression",
+    "classification": "progression_deprioritized_skip_balancing",
     "tags": ["Upgrades", "Magic"]
   },
   {


### PR DESCRIPTION
## What is this fixing or adding?
* Added `deprioritized` flag to Easter Eggs, as they should not be placed in priority locations.
* Added `deprioritized` and `skip_balancing` flags to magic types besides Carrot Shooter, as they only are progression in advanced knowledge seeds.

## How was this tested?
Fuzzing.

## If this makes graphical changes, please attach screenshots.
N/A